### PR TITLE
Add ThrowingFunc family of Function interfaces.

### DIFF
--- a/src/main/java/rx/util/async/functions/ThrowingFunc1.java
+++ b/src/main/java/rx/util/async/functions/ThrowingFunc1.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.util.async.functions;
+
+import rx.functions.Function;
+
+/**
+ * Represents a function with one argument that can throw an exception.
+ */
+public interface ThrowingFunc1<T, R> extends Function {
+    R call(T t) throws Exception;
+}

--- a/src/main/java/rx/util/async/functions/ThrowingFunc2.java
+++ b/src/main/java/rx/util/async/functions/ThrowingFunc2.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.util.async.functions;
+
+import rx.functions.Function;
+
+/**
+ * Represents a function with two arguments that can throw an exception.
+ */
+public interface ThrowingFunc2<T1, T2, R> extends Function {
+    R call(T1 t1, T2 t2) throws Exception;
+}

--- a/src/main/java/rx/util/async/functions/ThrowingFunc3.java
+++ b/src/main/java/rx/util/async/functions/ThrowingFunc3.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.util.async.functions;
+
+import rx.functions.Function;
+
+/**
+ * Represents a function with three arguments that can throw an exception.
+ */
+public interface ThrowingFunc3<T1, T2, T3, R> extends Function {
+    R call(T1 t1, T2 t2, T3 t3) throws Exception;
+}

--- a/src/main/java/rx/util/async/functions/ThrowingFunc4.java
+++ b/src/main/java/rx/util/async/functions/ThrowingFunc4.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.util.async.functions;
+
+import rx.functions.Function;
+
+/**
+ * Represents a function with four arguments that can throw an exception.
+ */
+public interface ThrowingFunc4<T1, T2, T3, T4, R> extends Function {
+    R call(T1 t1, T2 t2, T3 t3, T4 t4) throws Exception;
+}

--- a/src/main/java/rx/util/async/functions/ThrowingFunc5.java
+++ b/src/main/java/rx/util/async/functions/ThrowingFunc5.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.util.async.functions;
+
+import rx.functions.Function;
+
+/**
+ * Represents a function with five arguments that can throw an exception.
+ */
+public interface ThrowingFunc5<T1, T2, T3, T4, T5, R> extends Function {
+    R call(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5) throws Exception;
+}

--- a/src/main/java/rx/util/async/functions/ThrowingFunc6.java
+++ b/src/main/java/rx/util/async/functions/ThrowingFunc6.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.util.async.functions;
+
+import rx.functions.Function;
+
+/**
+ * Represents a function with six arguments that can throw an exception.
+ */
+public interface ThrowingFunc6<T1, T2, T3, T4, T5, T6, R> extends Function {
+    R call(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6) throws Exception;
+}

--- a/src/main/java/rx/util/async/functions/ThrowingFunc7.java
+++ b/src/main/java/rx/util/async/functions/ThrowingFunc7.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.util.async.functions;
+
+import rx.functions.Function;
+
+/**
+ * Represents a function with seven arguments that can throw an exception.
+ */
+public interface ThrowingFunc7<T1, T2, T3, T4, T5, T6, T7, R> extends Function {
+    R call(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7) throws Exception;
+}

--- a/src/main/java/rx/util/async/functions/ThrowingFunc8.java
+++ b/src/main/java/rx/util/async/functions/ThrowingFunc8.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.util.async.functions;
+
+import rx.functions.Function;
+
+/**
+ * Represents a function with eight arguments that can throw an exception.
+ */
+public interface ThrowingFunc8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends Function {
+    R call(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8) throws Exception;
+}

--- a/src/main/java/rx/util/async/functions/ThrowingFunc9.java
+++ b/src/main/java/rx/util/async/functions/ThrowingFunc9.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.util.async.functions;
+
+import rx.functions.Function;
+
+/**
+ * Represents a function with nine arguments that can throw an exception.
+ */
+public interface ThrowingFunc9<T1, T2, T3, T4, T5, T6, T7, T8, T9, R> extends Function {
+    R call(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9) throws Exception;
+}

--- a/src/main/java/rx/util/async/functions/ThrowingFuncN.java
+++ b/src/main/java/rx/util/async/functions/ThrowingFuncN.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.util.async.functions;
+
+import rx.functions.Function;
+
+/**
+ * Represents a vector-argument function that can throw an exception.
+ */
+public interface ThrowingFuncN<R> extends Function {
+    R call(Object... args) throws Exception;
+}

--- a/src/main/java/rx/util/async/functions/ThrowingFunctions.java
+++ b/src/main/java/rx/util/async/functions/ThrowingFunctions.java
@@ -1,0 +1,289 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.util.async.functions;
+
+import java.util.concurrent.Callable;
+
+/**
+ * Helper methods for converting throwing functions into Callables
+ */
+public class ThrowingFunctions {
+    private ThrowingFunctions() {
+        throw new IllegalStateException("No instances!");
+    }
+    
+    /**
+     * Converts a throwing function and its argument into a {@link Callable}.
+     * 
+     * @param <T1> the first parameter type
+     * @param <R> the result type
+     * @param func a throwing function to convert into a callable
+     * @param t1 the input to apply to the throwing function
+     * @return A callable that when called will apply the provided argument to the provided throwing function
+     */
+    public static <T1, R> Callable<R> toCallable(final ThrowingFunc1<? super T1, ? extends R> func, final T1 t1)
+    {
+	return new Callable<R>() {
+	    @Override
+	    public R call() throws Exception {
+		return func.call(t1);
+	    }
+	};
+    }
+    
+    /**
+     * Converts a throwing function and its arguments into a {@link Callable}.
+     * 
+     * @param <T1> the first parameter type
+     * @param <T2> the second parameter type
+     * @param <R> the result type
+     * @param func a throwing function to convert into a callable
+     * @param t1 the first input to apply to the throwing function
+     * @param t2 the second input to apply to the throwing function
+     * @return A callable that when called will apply the provided arguments to the provided throwing function
+     */
+    public static <T1, T2, R> Callable<R> toCallable(final ThrowingFunc2<? super T1, ? super T2, ? extends R> func, final T1 t1, final T2 t2)
+    {
+	return new Callable<R>() {
+	    @Override
+	    public R call() throws Exception {
+		return func.call(t1, t2);
+	    }
+	};
+    }
+    
+    /**
+     * Converts a throwing function and its arguments into a {@link Callable}.
+     * 
+     * @param <T1> the first parameter type
+     * @param <T2> the second parameter type
+     * @param <T3> the third parameter type
+     * @param <R> the result type
+     * @param func a throwing function to convert into a callable
+     * @param t1 the first input to apply to the throwing function
+     * @param t2 the second input to apply to the throwing function
+     * @param t3 the third input to apply to the throwing function
+     * @return A callable that when called will apply the provided arguments to the provided throwing function
+     */
+    public static <T1, T2, T3, R> Callable<R> toCallable(final ThrowingFunc3<? super T1, ? super T2, ? super T3, ? extends R> func, final T1 t1, final T2 t2, final T3 t3)
+    {
+	return new Callable<R>() {
+	    @Override
+	    public R call() throws Exception {
+		return func.call(t1, t2, t3);
+	    }
+	};
+    }
+    
+    /**
+     * Converts a throwing function and its arguments into a {@link Callable}.
+     * 
+     * @param <T1> the first parameter type
+     * @param <T2> the second parameter type
+     * @param <T3> the third parameter type
+     * @param <T4> the fourth parameter type
+     * @param <R> the result type
+     * @param func a throwing function to convert into a callable
+     * @param t1 the first input to apply to the throwing function
+     * @param t2 the second input to apply to the throwing function
+     * @param t3 the third input to apply to the throwing function
+     * @param t4 the fourth input to apply to the throwing function
+     * @return A callable that when called will apply the provided arguments to the provided throwing function
+     */
+    public static <T1, T2, T3, T4, R> Callable<R> toCallable(final ThrowingFunc4<? super T1, ? super T2, ? super T3, ? super T4, ? extends R> func, final T1 t1, final T2 t2, final T3 t3, final T4 t4)
+    {
+	return new Callable<R>() {
+	    @Override
+	    public R call() throws Exception {
+		return func.call(t1, t2, t3, t4);
+	    }
+	};
+    }
+    
+    /**
+     * Converts a throwing function and its arguments into a {@link Callable}.
+     * 
+     * @param <T1> the first parameter type
+     * @param <T2> the second parameter type
+     * @param <T3> the third parameter type
+     * @param <T4> the fourth parameter type
+     * @param <T5> the fifth parameter type
+     * @param <R> the result type
+     * @param func a throwing function to convert into a callable
+     * @param t1 the first input to apply to the throwing function
+     * @param t2 the second input to apply to the throwing function
+     * @param t3 the third input to apply to the throwing function
+     * @param t4 the fourth input to apply to the throwing function
+     * @param t5 the fifth input to apply to the throwing function
+     * @return A callable that when called will apply the provided arguments to the provided throwing function
+     */
+    public static <T1, T2, T3, T4, T5, R> Callable<R> toCallable(final ThrowingFunc5<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? extends R> func, final T1 t1, final T2 t2, final T3 t3, final T4 t4, final T5 t5)
+    {
+	return new Callable<R>() {
+	    @Override
+	    public R call() throws Exception {
+		return func.call(t1, t2, t3, t4, t5);
+	    }
+	};
+    }
+    
+    /**
+     * Converts a throwing function and its arguments into a {@link Callable}.
+     * 
+     * @param <T1> the first parameter type
+     * @param <T2> the second parameter type
+     * @param <T3> the third parameter type
+     * @param <T4> the fourth parameter type
+     * @param <T5> the fifth parameter type
+     * @param <T6> the fifth parameter type
+     * @param <R> the result type
+     * @param func a throwing function to convert into a callable
+     * @param t1 the first input to apply to the throwing function
+     * @param t2 the second input to apply to the throwing function
+     * @param t3 the third input to apply to the throwing function
+     * @param t4 the fourth input to apply to the throwing function
+     * @param t5 the fifth input to apply to the throwing function
+     * @param t6 the sixth input to apply to the throwing function
+     * @return A callable that when called will apply the provided arguments to the provided throwing function
+     */
+    public static <T1, T2, T3, T4, T5, T6, R> Callable<R> toCallable(final ThrowingFunc6<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? extends R> func, final T1 t1, final T2 t2, final T3 t3, final T4 t4, final T5 t5, final T6 t6)
+    {
+	return new Callable<R>() {
+	    @Override
+	    public R call() throws Exception {
+		return func.call(t1, t2, t3, t4, t5, t6);
+	    }
+	};
+    }
+    
+    /**
+     * Converts a throwing function and its arguments into a {@link Callable}.
+     * 
+     * @param <T1> the first parameter type
+     * @param <T2> the second parameter type
+     * @param <T3> the third parameter type
+     * @param <T4> the fourth parameter type
+     * @param <T5> the fifth parameter type
+     * @param <T6> the sixth parameter type
+     * @param <T7> the seventh parameter type
+     * @param <R> the result type
+     * @param func a throwing function to convert into a callable
+     * @param t1 the first input to apply to the throwing function
+     * @param t2 the second input to apply to the throwing function
+     * @param t3 the third input to apply to the throwing function
+     * @param t4 the fourth input to apply to the throwing function
+     * @param t5 the fifth input to apply to the throwing function
+     * @param t6 the sixth input to apply to the throwing function
+     * @param t7 the seventh input to apply to the throwing function
+     * @return A callable that when called will apply the provided arguments to the provided throwing function
+     */
+    public static <T1, T2, T3, T4, T5, T6, T7, R> Callable<R> toCallable(final ThrowingFunc7<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? extends R> func, final T1 t1, final T2 t2, final T3 t3, final T4 t4, final T5 t5, final T6 t6, final T7 t7)
+    {
+	return new Callable<R>() {
+	    @Override
+	    public R call() throws Exception {
+		return func.call(t1, t2, t3, t4, t5, t6, t7);
+	    }
+	};
+    }
+    
+    /**
+     * Converts a throwing function and its arguments into a {@link Callable}.
+     * 
+     * @param <T1> the first parameter type
+     * @param <T2> the second parameter type
+     * @param <T3> the third parameter type
+     * @param <T4> the fourth parameter type
+     * @param <T5> the fifth parameter type
+     * @param <T6> the sixth parameter type
+     * @param <T7> the seventh parameter type
+     * @param <T8> the eighth parameter type
+     * @param <R> the result type
+     * @param func a throwing function to convert into a callable
+     * @param t1 the first input to apply to the throwing function
+     * @param t2 the second input to apply to the throwing function
+     * @param t3 the third input to apply to the throwing function
+     * @param t4 the fourth input to apply to the throwing function
+     * @param t5 the fifth input to apply to the throwing function
+     * @param t6 the sixth input to apply to the throwing function
+     * @param t7 the seventh input to apply to the throwing function
+     * @param t8 the eighth input to apply to the throwing function
+     * @return A callable that when called will apply the provided arguments to the provided throwing function
+     */
+    public static <T1, T2, T3, T4, T5, T6, T7, T8, R> Callable<R> toCallable(final ThrowingFunc8<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? extends R> func, final T1 t1, final T2 t2, final T3 t3, final T4 t4, final T5 t5, final T6 t6, final T7 t7, final T8 t8)
+    {
+	return new Callable<R>() {
+	    @Override
+	    public R call() throws Exception {
+		return func.call(t1, t2, t3, t4, t5, t6, t7, t8);
+	    }
+	};
+    }
+    
+    /**
+     * Converts a throwing function and its arguments into a {@link Callable}.
+     * 
+     * @param <T1> the first parameter type
+     * @param <T2> the second parameter type
+     * @param <T3> the third parameter type
+     * @param <T4> the fourth parameter type
+     * @param <T5> the fifth parameter type
+     * @param <T6> the sixth parameter type
+     * @param <T7> the seventh parameter type
+     * @param <T8> the eighth parameter type
+     * @param <T9> the ninth parameter type
+     * @param <R> the result type
+     * @param func a throwing function to convert into a callable
+     * @param t1 the first input to apply to the throwing function
+     * @param t2 the second input to apply to the throwing function
+     * @param t3 the third input to apply to the throwing function
+     * @param t4 the fourth input to apply to the throwing function
+     * @param t5 the fifth input to apply to the throwing function
+     * @param t6 the sixth input to apply to the throwing function
+     * @param t7 the seventh input to apply to the throwing function
+     * @param t8 the eighth input to apply to the throwing function
+     * @param t9 the ninth input to apply to the throwing function
+     * @return A callable that when called will apply the provided arguments to the provided throwing function
+     */
+    public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, R> Callable<R> toCallable(final ThrowingFunc9<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? super T9, ? extends R> func, final T1 t1, final T2 t2, final T3 t3, final T4 t4, final T5 t5, final T6 t6, final T7 t7, final T8 t8, final T9 t9)
+    {
+	return new Callable<R>() {
+	    @Override
+	    public R call() throws Exception {
+		return func.call(t1, t2, t3, t4, t5, t6, t7, t8, t9);
+	    }
+	};
+    }
+    
+    /**
+     * Converts a throwing function and its argument into a {@link Callable}.
+     * 
+     * @param <T1> the first parameter type
+     * @param <R> the result type
+     * @param func a throwing function to convert into a callable
+     * @param args the input to apply to the throwing function
+     * @return A callable that when called will apply the provided arguments to the provided throwing function
+     */
+    public static <R> Callable<R> toCallable(final ThrowingFuncN<? extends R> func, final Object... args)
+    {
+	return new Callable<R>() {
+	    @Override
+	    public R call() throws Exception {
+		return func.call(args);
+	    }
+	};
+    }
+}

--- a/src/test/java/rx/util/async/functions/ThrowingFunctionsTest.java
+++ b/src/test/java/rx/util/async/functions/ThrowingFunctionsTest.java
@@ -1,0 +1,233 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.util.async.functions;
+
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class ThrowingFunctionsTest {
+    @Test
+    public void testThrowingFunc1ToCallable() throws Exception {
+        ThrowingFunc1<String, String> func = Mockito.mock(ThrowingFunc1.class);
+        
+        ThrowingFunctions.toCallable(func, "First")
+                         .call();
+        
+        Mockito.verify(func).call("First");
+    }
+    
+    @Test(expected=Exception.class)
+    public void testThrowingFunc1ToCallableThrows() throws Exception {
+        ThrowingFunc1<String, String> func = Mockito.mock(ThrowingFunc1.class);
+        when(func.call(Mockito.anyString())).thenThrow(new Exception());
+        
+        ThrowingFunctions.toCallable(func, "First")
+                         .call();
+        
+        Mockito.verify(func).call("First");
+    }
+    
+    @Test
+    public void testThrowingFunc2ToCallableThrows() throws Exception {
+        ThrowingFunc2<String, String, String> func = Mockito.mock(ThrowingFunc2.class);
+        
+        ThrowingFunctions.toCallable(func, "First", "Second")
+                         .call();
+        
+        Mockito.verify(func).call("First", "Second");
+    }
+    
+    @Test(expected=Exception.class)
+    public void testThrowingFunc2ToCallable() throws Exception {
+        ThrowingFunc2<String, String, String> func = Mockito.mock(ThrowingFunc2.class);
+        when(func.call(Mockito.anyString(), Mockito.anyString())).thenThrow(new Exception());
+        
+        ThrowingFunctions.toCallable(func, "First", "Second")
+                         .call();
+        
+        Mockito.verify(func).call("First", "Second");
+    }
+    
+    @Test
+    public void testThrowingFunc3ToCallable() throws Exception {
+        ThrowingFunc3<String, String, String, String> func = Mockito.mock(ThrowingFunc3.class);
+        
+        ThrowingFunctions.toCallable(func, "First", "Second", "Third")
+                         .call();
+        
+        Mockito.verify(func).call("First", "Second", "Third");
+    }
+    
+    @Test(expected=Exception.class)
+    public void testThrowingFunc3ToCallableThrows() throws Exception {
+        ThrowingFunc3<String, String, String, String> func = Mockito.mock(ThrowingFunc3.class);
+        when(func.call(Mockito.anyString(), Mockito.anyString(), Mockito.anyString())).thenThrow(new Exception());
+        
+        ThrowingFunctions.toCallable(func, "First", "Second", "Third")
+                         .call();
+        
+        Mockito.verify(func).call("First", "Second", "Third");
+    }
+    
+    @Test
+    public void testThrowingFunc4ToCallable() throws Exception {
+        ThrowingFunc4<String, String, String, String, String> func = Mockito.mock(ThrowingFunc4.class);
+        
+        ThrowingFunctions.toCallable(func, "First", "Second", "Third", "Fourth")
+                         .call();
+        
+        Mockito.verify(func).call("First", "Second", "Third", "Fourth");
+    }
+    
+    @Test(expected=Exception.class)
+    public void testThrowingFunc4ToCallableThrows() throws Exception {
+        ThrowingFunc4<String, String, String, String, String> func = Mockito.mock(ThrowingFunc4.class);
+        when(func.call(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString())).thenThrow(new Exception());
+        
+        ThrowingFunctions.toCallable(func, "First", "Second", "Third", "Fourth")
+                         .call();
+        
+        Mockito.verify(func).call("First", "Second", "Third", "Fourth");
+    }
+    
+    @Test
+    public void testThrowingFunc5ToCallable() throws Exception {
+        ThrowingFunc5<String, String, String, String, String, String> func = Mockito.mock(ThrowingFunc5.class);
+        
+        ThrowingFunctions.toCallable(func, "First", "Second", "Third", "Fourth", "Fifth")
+                         .call();
+        
+        Mockito.verify(func).call("First", "Second", "Third", "Fourth", "Fifth");
+    }
+    
+    @Test(expected=Exception.class)
+    public void testThrowingFunc5ToCallableThrows() throws Exception {
+        ThrowingFunc5<String, String, String, String, String, String> func = Mockito.mock(ThrowingFunc5.class);
+        when(func.call(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString())).thenThrow(new Exception());
+        
+        ThrowingFunctions.toCallable(func, "First", "Second", "Third", "Fourth", "Fifth")
+                         .call();
+        
+        Mockito.verify(func).call("First", "Second", "Third", "Fourth", "Fifth");
+    }
+    
+    @Test
+    public void testThrowingFunc6ToCallable() throws Exception {
+        ThrowingFunc6<String, String, String, String, String, String, String> func = Mockito.mock(ThrowingFunc6.class);
+        
+        ThrowingFunctions.toCallable(func, "First", "Second", "Third", "Fourth", "Fifth", "Sixth")
+                         .call();
+        
+        Mockito.verify(func).call("First", "Second", "Third", "Fourth", "Fifth", "Sixth");
+    }
+    
+    @Test(expected=Exception.class)
+    public void testThrowingFunc6ToCallableThrows() throws Exception {
+        ThrowingFunc6<String, String, String, String, String, String, String> func = Mockito.mock(ThrowingFunc6.class);
+        when(func.call(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString())).thenThrow(new Exception());
+        
+        ThrowingFunctions.toCallable(func, "First", "Second", "Third", "Fourth", "Fifth", "Sixth")
+                         .call();
+        
+        Mockito.verify(func).call("First", "Second", "Third", "Fourth", "Fifth", "Sixth");
+    }
+    
+    @Test
+    public void testThrowingFunc7ToCallable() throws Exception {
+        ThrowingFunc7<String, String, String, String, String, String, String, String> func = Mockito.mock(ThrowingFunc7.class);
+        
+        ThrowingFunctions.toCallable(func, "First", "Second", "Third", "Fourth", "Fifth", "Sixth", "Seventh")
+                         .call();
+        
+        Mockito.verify(func).call("First", "Second", "Third", "Fourth", "Fifth", "Sixth", "Seventh");
+    }
+    
+    @Test(expected=Exception.class)
+    public void testThrowingFunc7ToCallableThrows() throws Exception {
+        ThrowingFunc7<String, String, String, String, String, String, String, String> func = Mockito.mock(ThrowingFunc7.class);
+        when(func.call(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString())).thenThrow(new Exception());
+        
+        ThrowingFunctions.toCallable(func, "First", "Second", "Third", "Fourth", "Fifth", "Sixth", "Seventh")
+                         .call();
+        
+        Mockito.verify(func).call("First", "Second", "Third", "Fourth", "Fifth", "Sixth", "Seventh");
+    }
+    
+    @Test
+    public void testThrowingFunc8ToCallable() throws Exception {
+        ThrowingFunc8<String, String, String, String, String, String, String, String, String> func = Mockito.mock(ThrowingFunc8.class);
+        
+        ThrowingFunctions.toCallable(func, "First", "Second", "Third", "Fourth", "Fifth", "Sixth", "Seventh", "Eighth")
+                         .call();
+        
+        Mockito.verify(func).call("First", "Second", "Third", "Fourth", "Fifth", "Sixth", "Seventh", "Eighth");
+    }
+    
+    @Test(expected=Exception.class)
+    public void testThrowingFunc8ToCallableThrows() throws Exception {
+        ThrowingFunc8<String, String, String, String, String, String, String, String, String> func = Mockito.mock(ThrowingFunc8.class);
+        when(func.call(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString())).thenThrow(new Exception());
+        
+        ThrowingFunctions.toCallable(func, "First", "Second", "Third", "Fourth", "Fifth", "Sixth", "Seventh", "Eighth")
+                         .call();
+        
+        Mockito.verify(func).call("First", "Second", "Third", "Fourth", "Fifth", "Sixth", "Seventh", "Eighth");
+    }
+    
+    @Test
+    public void testThrowingFunc9ToCallable() throws Exception {
+        ThrowingFunc9<String, String, String, String, String, String, String, String, String, String> func = Mockito.mock(ThrowingFunc9.class);
+        
+        ThrowingFunctions.toCallable(func, "First", "Second", "Third", "Fourth", "Fifth", "Sixth", "Seventh", "Eighth", "Ninth")
+                         .call();
+        
+        Mockito.verify(func).call("First", "Second", "Third", "Fourth", "Fifth", "Sixth", "Seventh", "Eighth", "Ninth");
+    }
+    
+    @Test(expected=Exception.class)
+    public void testThrowingFunc9ToCallableThrows() throws Exception {
+        ThrowingFunc9<String, String, String, String, String, String, String, String, String, String> func = Mockito.mock(ThrowingFunc9.class);
+        when(func.call(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString())).thenThrow(new Exception());
+        
+        ThrowingFunctions.toCallable(func, "First", "Second", "Third", "Fourth", "Fifth", "Sixth", "Seventh", "Eighth", "Ninth")
+                         .call();
+        
+        Mockito.verify(func).call("First", "Second", "Third", "Fourth", "Fifth", "Sixth", "Seventh", "Eighth", "Ninth");
+    }
+    
+    @Test
+    public void testThrowingFuncNToCallable() throws Exception {
+        ThrowingFuncN<String> func = Mockito.mock(ThrowingFuncN.class);
+        
+        ThrowingFunctions.toCallable(func, "First", "Second", "Third", "Fourth", "Fifth", "Sixth", "Seventh", "Eighth", "Ninth", "Tenth")
+                         .call();
+        
+        Mockito.verify(func).call("First", "Second", "Third", "Fourth", "Fifth", "Sixth", "Seventh", "Eighth", "Ninth", "Tenth");
+    }
+    
+    @Test(expected=Exception.class)
+    public void testThrowingFuncNToCallableThrows() throws Exception {
+        ThrowingFuncN<String> func = Mockito.mock(ThrowingFuncN.class);
+        when(func.call(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString())).thenThrow(new Exception());
+        
+        ThrowingFunctions.toCallable(func, "First", "Second", "Third", "Fourth", "Fifth", "Sixth", "Seventh", "Eighth", "Ninth", "Tenth")
+                         .call();
+        
+        Mockito.verify(func).call("First", "Second", "Third", "Fourth", "Fifth", "Sixth", "Seventh", "Eighth", "Ninth", "Tenth");
+    }
+}


### PR DESCRIPTION
1. Added `ThrowingFunc{1 ... 9, N}` interfaces.
2. Added 2 static helper methods in `Async` for each throwing func to create an async function.
3. Added a utility class `ThrowingFunctions` with methods to convert each throwing function into a `Callable`.

This resolves #5.
