### PR TITLE
bump to RxJava version to 1.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'rxjava-project'
 apply plugin: 'java'
 
 dependencies {
-    compile 'io.reactivex:rxjava:1.0.+'
+    compile 'io.reactivex:rxjava:1.1.+'
     testCompile 'junit:junit-dep:4.10'
     testCompile 'org.mockito:mockito-core:1.8.5'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'rxjava-project'
 apply plugin: 'java'
 
 dependencies {
-    compile 'io.reactivex:rxjava:1.1.+'
+    compile 'io.reactivex:rxjava:1.1.0'
     testCompile 'junit:junit-dep:4.10'
     testCompile 'org.mockito:mockito-core:1.8.5'
 }

--- a/src/main/java/rx/util/async/Async.java
+++ b/src/main/java/rx/util/async/Async.java
@@ -2002,7 +2002,10 @@ public final class Async {
      *         subscribes
      * @see #start(rx.functions.Func0) 
      * @see <a href="https://github.com/ReactiveX/RxJava/wiki/Async-Operators#wiki-fromcallable">RxJava Wiki: fromCallable()</a>
+     *
+     * @deprecated use {@link Observable#fromCallable(Callable)}
      */
+    @Deprecated
     public static <R> Observable<R> fromCallable(Callable<? extends R> callable) {
         return fromCallable(callable, Schedulers.computation());
     }


### PR DESCRIPTION
also:

deprecate `Async#fromCallable(Callable)` in favor of `Observable#fromCallable(Callable)`
